### PR TITLE
Fixed errors in GroupHug simulation code

### DIFF
--- a/mechanisms/group_hug_mechanism.py
+++ b/mechanisms/group_hug_mechanism.py
@@ -10,11 +10,11 @@ from mechanisms.voting_mechanism import VotingMechanism
 
 #Set default amounts for each NFT to contribute to individual 
 DEFAULT_NFT_WEIGHTS = {
-    "FUND_MOD1": 3.0,
-    "FUND_MOD2": 3.0,
-    "FUND_MOD3": 3.0,
-    "FUND_MOD4": 3.0,
-    "FUND_MOD5": 3.0,
+    "FUND_MOD_1": 3.0,
+    "FUND_MOD_2": 3.0,
+    "FUND_MOD_3": 3.0,
+    "FUND_MOD_4": 3.0,
+    "FUND_MOD_5": 3.0,
     "BARCAMP_PARIS_23": 2.0,
     "NFTREP_V1": 1.0,
     "STUDY_GROUP_HOST_C2_22_23": 1.0,
@@ -139,7 +139,7 @@ class GroupHug(VotingMechanism):
             extracted_voters.append(Voter(choice, nfts))
         
         # Analyze election results
-        aggregate_vote = self.vote(extracted_candidates, extracted_voters)
+        aggregate_vote = self.vote(extracted_candidates, extracted_voters, verbose = True)
         winner = self.declare_winner(aggregate_vote)
 
         return (winner, aggregate_vote)
@@ -175,11 +175,10 @@ class GroupHug(VotingMechanism):
 
     def weight_intellectual(self, voter):
 
-            w = 0 
-            nfts = voter.nfts
-            
-            for intellectual_nft in self.intellectuals_nft_list:
-                w += self.nft_weights.get(intellectual_nft, 0)
+            w = 0             
+            for nft in voter.nfts:
+                if nft in self.intellectuals_nft_list:
+                    w += self.nft_weights[nft]
 
             return w
 
@@ -260,12 +259,12 @@ class GroupHug(VotingMechanism):
         else: return {c: round(100 * points[c] / total) for c in points}
     
     # Helper function to convert a dicitionary to a more readable form. 
-    def str_dict(d):
+    def str_dict(self, d):
         return str(dict(sorted(d.items())))
 
 
     # Main vote-counting mechanics
-    def vote(self, candidates, voters, verbose: str = False):
+    def vote(self, candidates, voters, verbose = False):
         eligible = [v for v in voters if not v.isCandidate]   # Candidates are not allowed to vote!
 
         experts = self.normalize(self.ask_the_experts(candidates, eligible))
@@ -278,7 +277,6 @@ class GroupHug(VotingMechanism):
             print("Intellectuals: " + self.str_dict(intellectuals))
             print("Participants: " + self.str_dict(participants))
             print("Community: " + self.str_dict(community))
-            print ("\n---\n")
 
         aggregate = {c: 0 for c in candidates}
 

--- a/notebooks/grouphug_notebook.ipynb
+++ b/notebooks/grouphug_notebook.ipynb
@@ -6,12 +6,12 @@
    "source": [
     "# Test Notebook for GroupHug \n",
     "\n",
-    "This is based on work by @joandk from the original repository. "
+    "This is an adaptation of work by @joanbp-dk from https://github.com/joanbp-dk/Repbased_voting_playground. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,17 +28,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Change these and pass as argument in the GH constructor if you want to play with the weights\n",
     "\n",
-    "DEFAULT_NFT_SCORES = {\n",
-    "    \"FUND_MOD1\": 3.0,\n",
-    "    \"FUND_MOD2\": 3.0,\n",
-    "    \"FUND_MOD3\": 3.0,\n",
-    "    \"FUND_MOD4\": 3.0,\n",
-    "    \"FUND_MOD5\": 3.0,\n",
+    "CUSTOM_EXPERTS_GROUP_WEIGHT = 1\n",
+    "CUSTOM_INTELLECTUALS_GROUP_WEIGHT = 1\n",
+    "CUSTOM_PARTICIPANTS_GROUP_WEIGHT = 1\n",
+    "CUSTOM_COMMUNITY_GROUP_WEIGHT = 1\n",
+    "\n",
+    "CUSTOM_NFT_WEIGHTS = {\n",
+    "    \"FUND_MOD_1\": 3.0,\n",
+    "    \"FUND_MOD_2\": 3.0,\n",
+    "    \"FUND_MOD_3\": 3.0,\n",
+    "    \"FUND_MOD_4\": 3.0,\n",
+    "    \"FUND_MOD_5\": 3.0,\n",
     "    \"BARCAMP_PARIS_23\": 2.0,\n",
     "    \"NFTREP_V1\": 1.0,\n",
     "    \"STUDY_GROUP_HOST_C2_22_23\": 1.0,\n",
@@ -64,101 +70,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "voters_1 = {\n",
-    "    \"V1\": {},\n",
-    "    \"V2\": {\"FUND_MOD1\": 1.0, \n",
-    "           \"FUND_MOD2\": 1.0, \n",
-    "           \"FUND_MOD3\": 1.0, \n",
-    "           \"FUND_MOD4\": 1.0, \n",
-    "           \"FUND_MOD5\": 1.0},\n",
-    "    \"V3\": {},\n",
-    "    \"V4\": {\"FUND_MOD1\": 1.0},\n",
-    "    \"V5\": {\"FUND_MOD1\": 1.0, \n",
-    "           \"FUND_MOD2\": 1.0},\n",
-    "    \"V6\": {\"BARCAMP_PARIS_23\": 1.0},\n",
-    "    \"V7\": {\"STUDY_GROUP_HOST_FUND_22_23\": 1.0, \n",
-    "           \"LIVE_TRACK_4\": 1.0},\n",
-    "    \"V8\": {\"STUDY_GROUP_HOST_FUND_22_23\": 1.0},\n",
-    "    \"V9\": {\"STUDY_GROUP_HOST_FUND_22_23\": 1.0, \n",
-    "           \"LIVE_TRACK_1\": 1.0, \n",
-    "           \"LIVE_TRACK_2\": 1.0},\n",
-    "    \"V10\": {\"LIVE_TRACK_4\": 1.0, \n",
-    "            \"LIVE_TRACK_5\": 1.0},\n",
-    "}\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Input information about voters. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'V1': {},\n",
-       " 'V2': {'FUND_MOD1': True,\n",
-       "  'FUND_MOD2': True,\n",
-       "  'FUND_MOD3': True,\n",
-       "  'FUND_MOD4': True,\n",
-       "  'FUND_MOD5': True},\n",
-       " 'V3': {},\n",
-       " 'V4': {'FUND_MOD1': True},\n",
-       " 'V5': {'FUND_MOD1': True, 'FUND_MOD2': True},\n",
-       " 'V6': {'BARCAMP_PARIS_23': True},\n",
-       " 'V7': {'STUDY_GROUP_HOST_FUND_22_23': True, 'LIVE_TRACK_4': True},\n",
-       " 'V8': {'STUDY_GROUP_HOST_FUND_22_23': True},\n",
-       " 'V9': {'STUDY_GROUP_HOST_FUND_22_23': True,\n",
-       "  'LIVE_TRACK_1': True,\n",
-       "  'LIVE_TRACK_2': True},\n",
-       " 'V10': {'LIVE_TRACK_4': True, 'LIVE_TRACK_5': True}}"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "voters_1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "voter_choices_1 = {\n",
-    "    \n",
-    "    \"V1\": \"C4\",\n",
-    "    \"V2\": \"C2\",\n",
-    "    \"V3\": \"C2\",\n",
-    "    \"V4\": \"C3\",\n",
-    "    \"V5\": \"C4\",\n",
-    "    \"V6\": \"C3\",\n",
-    "    \"V7\": \"C1\",\n",
-    "    \"V8\": \"C4\",\n",
-    "    \"V9\": \"C2\",\n",
-    "    \"V10\": \"C4\",\n",
+    "    \"V1\": {\"FELLOWSHIP_COMM\": True},\n",
+    "    \"V2\": {\"FUND_MOD_1\": True},\n",
+    "    \"V3\": {\"FUND_MOD_1\": True,\n",
+    "           \"FUND_MOD_2\": True,\n",
+    "           \"LIVE_TRACK_1\": True},\n",
+    "    \"V4\": {\"LIVE_TRACK_6\": True,\n",
+    "           \"LIVE_TRACK_2\": True},\n",
+    "    \"V5\": {}\n",
     "}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "voter_choices_1 = {\n",
+    "    \n",
+    "    \"V1\": \"Candidate_A\",\n",
+    "    \"V2\": \"Candidate_A\",\n",
+    "    \"V3\": \"Candidate_B\",\n",
+    "    \"V4\": \"Candidate_A\",\n",
+    "    \"V5\": \"Candidate_A\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,43 +132,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'C4'"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "winner"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'C4': 45, 'C2': 30, 'C3': 10, 'C1': 15}"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "results"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Fixed errors in group_hug_mechanism.py and grouphug_notebook.ipynb:

1: Naming inconsistencies around the TE Fundamentals NFTs. 
2: An issue with the calculation of weights for the intellectuals' vote. 
3: A problem with the parameters of the str_dict helper function (which wasn't being called unless verbose output was turned on).

Minor changes: Different test input to better be able to check results. Exchanged a couple of variable names in the notebook file to make it more clear what they are meant for - they are currently not being used, though.